### PR TITLE
Releasing version 3.1 for Moodle 3.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# qtype_mtf Multiple True/False (MTF with multi-answers) ETHz (Seperated from qtype_scmc) question type for moodle 2.6+ to 3.x
+# qtype_mtf Multiple True/False (MTF with multi-answers) ETHz (Seperated from qtype_scmc) question type v 3.1 for Moodle 3.4+ (2019032200, 2019/03/22)
 
 *** Info regarding migration from qtype_multichoice (with Multi Answers Only) to qtype_mtf ***
 

--- a/version.php
+++ b/version.php
@@ -26,4 +26,4 @@ $plugin->component = 'qtype_mtf';
 $plugin->version = 2019032200;
 $plugin->requires = 2017111300; // Moodle >=3.4
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '2.1 for Moodle 3.4+';
+$plugin->release = '3.1 for Moodle 3.4+';


### PR DESCRIPTION
Dear qtype_mtf team.
Thanks for your terrific work!
It would be great if you could synchronize your somewhat exotic/intransparent version info to be the same all over the Moodle plugins directory, README.md, version.php and Git tags.
This branch gives an example of it. Now you would just have to add the 3.1 tag (I see you are doing a different numbering system in tags, up to you…) in case of a merge and release.
Best,
Luca